### PR TITLE
Fix issue with hardcoded Color/Grayscale names

### DIFF
--- a/server/scanjob.cpp
+++ b/server/scanjob.cpp
@@ -404,9 +404,9 @@ void ScanJob::Private::finishTransfer(std::ostream &os)
     }
     if(isProcessing()) {
         pEncoder->setResolutionDpi(mRes_dpi);
-        if(mColorMode == "Color")
+        if(mColorMode == mpScanner->colorScanModeName())
             pEncoder->setColorspace(ImageEncoder::RGB);
-        else if(mColorMode == "Gray")
+        else if(mColorMode == mpScanner->grayScanModeName())
             pEncoder->setColorspace(ImageEncoder::Grayscale);
         auto p = mpSession->parameters();
         pEncoder->setWidth(p->pixels_per_line);


### PR DESCRIPTION
On my brother scanner the color scanning mode is called '24bit Color[Fast]'

The hardcoded Color check was causing the scan to fail with 

 /root/AirSane/server/scanjob.cpp, line 417: encoder bytesPerLine (832) differs from SANE bytes_per_line (2496)

I think this commit fixes this.