### PR TITLE
server/server.cpp: fix error: '::strerror' has not been declared

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "server.h"
 
+#include <cstring>
 #include <cmath>
 #include <csignal>
 #include <ctime>


### PR DESCRIPTION
for GNU 12.1.1