### PR TITLE
improve duplex ADF handling

### DIFF
--- a/server/scanjob.cpp
+++ b/server/scanjob.cpp
@@ -129,6 +129,7 @@ struct ScanJob::Private
   std::string mScanSource, mIntent, mDocumentFormat, mColorMode;
   int mBitDepth, mRes_dpi;
   bool mColorScan;
+  bool mDuplex;
   double mLeft_px, mTop_px, mWidth_px, mHeight_px;
 
   std::atomic<int> mKind, mImagesCompleted;
@@ -310,7 +311,12 @@ ScanJob::Private::init(const ScanSettingsXml& settings, bool autoselectFormat, c
     mKind = single;
   }
   else if (inputSource == "Feeder") {
-    mScanSource = mpScanner->adfSourceName();
+    mDuplex = settings.getNumber("Duplex") == 1.0;
+    if (mDuplex) {
+        mScanSource = mpScanner->adfDuplexSourceName();
+    } else {
+        mScanSource = mpScanner->adfSimplexSourceName();
+    }
     double concatIfPossible = settings.getNumber("ConcatIfPossible");
     if (concatIfPossible == 1.0 && mDocumentFormat == HttpServer::MIME_TYPE_PDF)
       mKind = adfConcat;

--- a/server/scanner.h
+++ b/server/scanner.h
@@ -64,7 +64,8 @@ public:
   const std::vector<std::string>& txtColorSpaces() const;
   const std::vector<std::string>& colorModes() const;
   std::vector<std::string> platenSupportedIntents() const;
-  std::vector<std::string> adfSupportedIntents() const;
+  std::vector<std::string> adfSimplexSupportedIntents() const;
+  std::vector<std::string> adfDuplexSupportedIntents() const;
   const std::vector<std::string>& inputSources() const;
 
   int minResDpi() const;
@@ -77,7 +78,8 @@ public:
   bool hasDuplexAdf() const;
 
   std::string platenSourceName() const;
-  std::string adfSourceName() const;
+  std::string adfSimplexSourceName() const;
+  std::string adfDuplexSourceName() const;
   std::string grayScanModeName() const;
   std::string colorScanModeName() const;
 


### PR DESCRIPTION
Currently, AirSane detects the duplex capability and then replaces `<scan:AdfSimplexInputCaps>` with `<scan:AdfDuplexInputCaps>` in the the capabilities XML. However, according to the [eSCL spec](https://mopria.org/mopria-escl-specification), `AdfSimplexInputCaps` is still required, `AdfDuplexInputCaps` should be added as an extra element.

Additionally, when the client actually requests a duplex scan through eSCL, AirSane currently doesn't handle that parameter.

This PR addresses both problems and allows me to successfully run simplex and duplex scans with my Epson DS-1630 scanner (using the `epsonds` SANE backend and NAPS2 on Windows as a client).

related to #56