### PR TITLE
feat: add adfOption duplex when duplex is supported

### DIFF
--- a/server/scanner.cpp
+++ b/server/scanner.cpp
@@ -288,8 +288,11 @@ Scanner::Private::writeScannerCapabilitiesXml(std::ostream& os) const
       os << "</scan:AdfDuplexInputCaps>\r\n";
     }
     os << "<scan:AdfOptions>\r\n"
-       << "<scan:AdfOption>DetectPaperLoaded</scan:AdfOption>\r\n"
-       << "</scan:AdfOptions>\r\n"
+       << "<scan:AdfOption>DetectPaperLoaded</scan:AdfOption>\r\n";
+    if (mpAdfDuplex) {
+      os << "<scan:AdfOption>Duplex</scan:AdfOption>\r\n";
+    }
+    os << "</scan:AdfOptions>\r\n"
        << "</scan:Adf>\r\n";
   }
   os << "</scan:ScannerCapabilities>\r\n";


### PR DESCRIPTION
Without the 'Duplex' adf option in the ScannerCapabilities XML, the Mac Image Capture application does not show the duplex option.

<img width="342" height="342" alt="grafik" src="https://github.com/user-attachments/assets/3d0368e4-f7af-4b19-a6ff-e9de57842fd0" />
