### PR TITLE
 Fix false paper jam errors on Windows eSCL clients

### DIFF
--- a/server/scanner.cpp
+++ b/server/scanner.cpp
@@ -389,7 +389,7 @@ Scanner::Private::temporaryAdfStatusString()
   mTemporaryAdfStatus = SANE_STATUS_GOOD;
   switch (adfStatus) {
     case SANE_STATUS_GOOD:
-      return "ScannerAdfLoaded";
+      return isOpen() ? "ScannerAdfLoaded" : "ScannerAdfEmpty";
     case SANE_STATUS_JAMMED:
       return "ScannerAdfJam";
     case SANE_STATUS_COVER_OPEN:

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -641,6 +641,10 @@ Server::handleScannerRequest(ScannerList::value_type entry, const std::string& p
           response.setHeader(HttpServer::HTTP_HEADER_CONTENT_TYPE, job->documentFormat());
           response.setHeader(HttpServer::HTTP_HEADER_TRANSFER_ENCODING, "chunked");
           job->finishTransfer(response.send());
+        } else if (job->adfStatus() == SANE_STATUS_NO_DOCS) {
+          entry.pScanner->setTemporaryAdfStatus(job->adfStatus());
+          response.setStatus(HttpServer::HTTP_NOT_FOUND);
+          response.send();
         } else if (job->adfStatus() != SANE_STATUS_GOOD) {
           entry.pScanner->setTemporaryAdfStatus(job->adfStatus());
           response.setStatus(HttpServer::HTTP_CONFLICT);


### PR DESCRIPTION
  Two issues caused ADF-only scanners to misbehave with eSCL clients:

  1. ScannerStatus always reported ScannerAdfLoaded when idle, even with an empty feeder. Clients would attempt to pull from the ADF and fail. Now reports ScannerAdfEmpty when no scan session is active.

  2. When the ADF runs out of pages after a successful scan, the NextDocument endpoint returned HTTP 409 (Conflict). Windows interprets this as a paper jam. Now returns HTTP 404 (Not Found) for SANE_STATUS_NO_DOCS, reserving 409 for actual errors (jams, open covers). This matches the expected eSCL protocol behavior.

  Tested with HP Officejet 4200 (ADF-only) against Windows 10/11