### PR TITLE
CMakeInstall.txt:  Require at least CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(airsaned)
 


### PR DESCRIPTION
CMake will soon drop compatibility with versions < 3.10

See https://bugs.gentoo.org/975296